### PR TITLE
Fixes sums for visits

### DIFF
--- a/app/models/sell.rb
+++ b/app/models/sell.rb
@@ -13,13 +13,13 @@ class Sell < ActiveRecord::Base
     self.item.fix_sold
   end
 
-  trigger.after(:insert, :update).name('fix_sells_price') do
+  trigger.after(:insert, :update, :delete).name('fix_sells_price') do
     <<-SQL
       UPDATE visits SET price = (SELECT COALESCE(SUM(price * count), 0) FROM sells WHERE visit_id = NEW.visit_id AND deleted_at IS NULL) WHERE visits.id = NEW.visit_id;
     SQL
   end
 
-  trigger.after(:insert, :update).name('fix_sells_employee_share_sale') do
+  trigger.after(:insert, :update, :delete).name('fix_sells_employee_share_sale') do
     <<-SQL
       UPDATE visits SET employee_share_sale = (
         SELECT COALESCE(SUM(sells.price * sells.count), 0) FROM sells LEFT JOIN items ON items.id = sells.item_id WHERE sells.visit_id = NEW.visit_id AND sells.deleted_at IS NULL AND items.is_service = false) * 0.1
@@ -27,7 +27,7 @@ class Sell < ActiveRecord::Base
     SQL
   end
 
-  trigger.after(:insert, :update).name('fix_sells_employee_share_service') do
+  trigger.after(:insert, :update, :delete).name('fix_sells_employee_share_service') do
     <<-SQL
       UPDATE visits SET employee_share_service = (
         SELECT COALESCE(SUM(sells.price * sells.count), 0) FROM sells LEFT JOIN items ON items.id = sells.item_id WHERE sells.visit_id = NEW.visit_id AND sells.deleted_at IS NULL AND items.is_service = true) * 0.1

--- a/db/migrate/20160713064746_create_triggers_sells_insert_update_delete.rb
+++ b/db/migrate/20160713064746_create_triggers_sells_insert_update_delete.rb
@@ -1,0 +1,79 @@
+# This migration was auto-generated via `rake db:generate_trigger_migration'.
+# While you can edit this file, any changes you make to the definitions here
+# will be undone by the next auto-generated trigger migration.
+
+class CreateTriggersSellsInsertUpdateDelete < ActiveRecord::Migration
+  def up
+    drop_trigger("fix_sells_price", "sells", :generated => true)
+
+    drop_trigger("fix_sells_employee_share_sale", "sells", :generated => true)
+
+    drop_trigger("fix_sells_employee_share_service", "sells", :generated => true)
+
+    create_trigger("fix_sells_price", :generated => true, :compatibility => 1).
+        on("sells").
+        after(:insert, :update, :delete).
+        name("fix_sells_price") do
+      "      UPDATE visits SET price = (SELECT COALESCE(SUM(price * count), 0) FROM sells WHERE visit_id = NEW.visit_id AND deleted_at IS NULL) WHERE visits.id = NEW.visit_id;"
+    end
+
+    create_trigger("fix_sells_employee_share_sale", :generated => true, :compatibility => 1).
+        on("sells").
+        after(:insert, :update, :delete).
+        name("fix_sells_employee_share_sale") do
+      <<-SQL_ACTIONS
+      UPDATE visits SET employee_share_sale = (
+        SELECT COALESCE(SUM(sells.price * sells.count), 0) FROM sells LEFT JOIN items ON items.id = sells.item_id WHERE sells.visit_id = NEW.visit_id AND sells.deleted_at IS NULL AND items.is_service = false) * 0.1
+        WHERE visits.id = NEW.visit_id;
+      SQL_ACTIONS
+    end
+
+    create_trigger("fix_sells_employee_share_service", :generated => true, :compatibility => 1).
+        on("sells").
+        after(:insert, :update, :delete).
+        name("fix_sells_employee_share_service") do
+      <<-SQL_ACTIONS
+      UPDATE visits SET employee_share_service = (
+        SELECT COALESCE(SUM(sells.price * sells.count), 0) FROM sells LEFT JOIN items ON items.id = sells.item_id WHERE sells.visit_id = NEW.visit_id AND sells.deleted_at IS NULL AND items.is_service = true) * 0.1
+        WHERE visits.id = NEW.visit_id;
+      SQL_ACTIONS
+    end
+  end
+
+  def down
+    drop_trigger("fix_sells_price", "sells", :generated => true)
+
+    drop_trigger("fix_sells_employee_share_sale", "sells", :generated => true)
+
+    drop_trigger("fix_sells_employee_share_service", "sells", :generated => true)
+
+    create_trigger("fix_sells_price", :generated => true, :compatibility => 1).
+        on("sells").
+        after(:insert, :update).
+        name("fix_sells_price") do
+      "      UPDATE visits SET price = (SELECT COALESCE(SUM(price * count), 0) FROM sells WHERE visit_id = NEW.visit_id AND deleted_at IS NULL) WHERE visits.id = NEW.visit_id;"
+    end
+
+    create_trigger("fix_sells_employee_share_sale", :generated => true, :compatibility => 1).
+        on("sells").
+        after(:insert, :update).
+        name("fix_sells_employee_share_sale") do
+      <<-SQL_ACTIONS
+      UPDATE visits SET employee_share_sale = (
+        SELECT COALESCE(SUM(sells.price * sells.count), 0) FROM sells LEFT JOIN items ON items.id = sells.item_id WHERE sells.visit_id = NEW.visit_id AND sells.deleted_at IS NULL AND items.is_service = false) * 0.1
+        WHERE visits.id = NEW.visit_id;
+      SQL_ACTIONS
+    end
+
+    create_trigger("fix_sells_employee_share_service", :generated => true, :compatibility => 1).
+        on("sells").
+        after(:insert, :update).
+        name("fix_sells_employee_share_service") do
+      <<-SQL_ACTIONS
+      UPDATE visits SET employee_share_service = (
+        SELECT COALESCE(SUM(sells.price * sells.count), 0) FROM sells LEFT JOIN items ON items.id = sells.item_id WHERE sells.visit_id = NEW.visit_id AND sells.deleted_at IS NULL AND items.is_service = true) * 0.1
+        WHERE visits.id = NEW.visit_id;
+      SQL_ACTIONS
+    end
+  end
+end

--- a/db/migrate/20160713064756_fire_all_the_triggers.rb
+++ b/db/migrate/20160713064756_fire_all_the_triggers.rb
@@ -1,0 +1,6 @@
+class FireAllTheTriggers < ActiveRecord::Migration
+  def change
+    query = "UPDATE sells SET count = count;"
+    results = ActiveRecord::Base.connection.execute(query)
+  end
+end


### PR DESCRIPTION
- In special case that last activity on visit was deleted sell, that change was not recorded and thus the sums were wrong. This patch fixes the issue.
- Also triggers recalculation for all the affected data so that sums are correct.
- Fixes #85 