### PR TITLE
Customer table horizontal scroll

### DIFF
--- a/frontend/app/admin/customers/template.hbs
+++ b/frontend/app/admin/customers/template.hbs
@@ -25,44 +25,46 @@
     action="customersFiltered"
   }}
 
-<table class="admin-customers">
-  <thead>
-    <tr>
-      <th class="admin-customers-col-gender">{{th-sort action="sortBy" title=(t 'customer.gender') current=sortBy value='gender'}}</th>
-      <th class="admin-customers-col-visits-count">{{th-sort action="sortBy" title=(t 'customer.visits_length') current=sortBy value='visitsCount'}}</th>
-      <th class="admin-customers-col-last-visit">{{th-sort action="sortBy" title=(t 'customer.lastVisitDate') current=sortBy value='lastVisitDate'}}</th>
-      <th class="admin-customers-col-first-name">{{th-sort action="sortBy" title=(t 'customer.firstName') current=sortBy value='firstName'}}</th>
-      <th class="admin-customers-col-last-name">{{th-sort action="sortBy" title=(t 'customer.lastName') current=sortBy value='lastName'}}</th>
-      <th class="admin-customers-col-birth">{{th-sort action="sortBy" title=(t 'customer.birthdayIn') current=sortBy value='daysTillNextBirthday'}}</th>
-      <th class="admin-customers-col-phone">{{th-sort action="sortBy" title=(t 'customer.phone') current=sortBy value='phone'}}</th>
-      <th class="admin-customers-col-mail">{{th-sort action="sortBy" title=(t 'customer.mail') current=sortBy value='mail'}}</th>
-      <th class="admin-customers-col-note">{{th-sort action="sortBy" title=(t 'customer.note') current=sortBy value='note'}}</th>
-      <th class="admin-customers-col-action">{{t 'customer.action'}}</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    {{#each pagedCustomers as |customer|}}
+<div class="table-responsive">
+  <table class="admin-customers">
+    <thead>
       <tr>
-        <td>{{~x-customer/gender-icon gender=customer.gender~}}</td>
-        <td>{{customer.visitsCount}}</td>
-        <td>{{x-visit/last-visit customer=customer}}</td>
-        <td>{{customer.firstName}}</td>
-        <td>{{customer.lastName}}</td>
-        <td>
-          {{~x-customer/birthday customer=customer~}}
-        </td>
-        <td>{{customer.phone}}</td>
-        <td>{{customer.mail}}</td>
-        <td>{{customer.note}}</td>
-        <td class="text-right">
-          {{#link-to 'admin.customer' customer class='btn btn-default btn-xs'}}
-            {{fa-icon icon="pencil"}}
-          {{/link-to}}
-        </td>
+        <th class="admin-customers-col-first-name">{{th-sort action="sortBy" title=(t 'customer.firstName') current=sortBy value='firstName'}}</th>
+        <th class="admin-customers-col-last-name">{{th-sort action="sortBy" title=(t 'customer.lastName') current=sortBy value='lastName'}}</th>
+        <th class="admin-customers-col-phone">{{th-sort action="sortBy" title=(t 'customer.phone') current=sortBy value='phone'}}</th>
+        <th class="admin-customers-col-mail">{{th-sort action="sortBy" title=(t 'customer.mail') current=sortBy value='mail'}}</th>
+        <th class="admin-customers-col-last-visit">{{th-sort action="sortBy" title=(t 'customer.lastVisitDate') current=sortBy value='lastVisitDate'}}</th>
+        <th class="admin-customers-col-visits-count">{{th-sort action="sortBy" title=(t 'customer.visits_length') current=sortBy value='visitsCount'}}</th>
+        <th class="admin-customers-col-gender">{{th-sort action="sortBy" title=(t 'customer.gender') current=sortBy value='gender'}}</th>
+        <th class="admin-customers-col-birth">{{th-sort action="sortBy" title=(t 'customer.birthdayIn') current=sortBy value='daysTillNextBirthday'}}</th>
+        <th class="admin-customers-col-note">{{th-sort action="sortBy" title=(t 'customer.note') current=sortBy value='note'}}</th>
+        <th class="admin-customers-col-action">{{t 'customer.action'}}</th>
       </tr>
-    {{/each}}
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+      {{#each pagedCustomers as |customer|}}
+        <tr>
+          <td>{{customer.firstName}}</td>
+          <td>{{customer.lastName}}</td>
+          <td>{{customer.phone}}</td>
+          <td>{{customer.mail}}</td>
+          <td>{{x-visit/last-visit customer=customer}}</td>
+          <td>{{customer.visitsCount}}</td>
+          <td>{{~x-customer/gender-icon gender=customer.gender~}}</td>
+          <td>
+            {{~x-customer/birthday customer=customer~}}
+          </td>
+          <td>{{customer.note}}</td>
+          <td class="text-right">
+            {{#link-to 'admin.customer' customer class='btn btn-default btn-xs'}}
+              {{fa-icon icon="pencil"}}
+            {{/link-to}}
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>
 
 {{page-numbers content=pagedCustomers}}

--- a/frontend/tests/acceptance/admin/customers-test.js
+++ b/frontend/tests/acceptance/admin/customers-test.js
@@ -27,14 +27,14 @@ test('Basic layout', function(assert) {
     let $row = find('.admin-customers tbody tr:nth-of-type(1)');
     let [c] = customers;
     let expectedCells = [
-      '',
-      c.visitsCount,
-      moment(c.lastVisitDate).fromNow(),
       c.firstName,
       c.lastName,
-      moment(c.nextBirthday).fromNow(),
       c.phone,
       c.mail,
+      moment(c.lastVisitDate).fromNow(),
+      c.visitsCount,
+      '',
+      moment(c.nextBirthday).fromNow(),
       c.note
     ];
     expectedCells.forEach(function(cell, i) {
@@ -44,7 +44,7 @@ test('Basic layout', function(assert) {
 });
 
 test('Table sorting', function(assert) {
-  assert.expect(8);
+  assert.expect(7);
 
   let customersSorted;
   let customers = server.createList('customer', 3);
@@ -55,45 +55,39 @@ test('Table sorting', function(assert) {
 
   andThen(function() {
     customersSorted = customers.sortBy('nextBirthday');
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(2)').text(), customersSorted[0].visitsCount, 'Default sorting is by next birthday');
+    let expect = moment(customersSorted[0].nextBirthday).fromNow();
+    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(8)').text(), expect, 'Default sorting is by next birthday');
   });
 
   click('th.admin-customers-col-last-visit .th-sort');
   andThen(function() {
     customersSorted = customers.sortBy('lastVisitDate');
     let expect = moment().to(customersSorted[0].lastVisitDate);
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(3)').text(), expect, 'Sorting by last visit date');
+    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(5)').text(), expect, 'Sorting by last visit date');
   });
 
   click('th.admin-customers-col-first-name .th-sort');
   andThen(function() {
     customersSorted = customers.sortBy('firstName');
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(4)').text(), customersSorted[0].firstName, 'Sorting by first name');
+    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(1)').text(), customersSorted[0].firstName, 'Sorting by first name');
   });
 
   click('th.admin-customers-col-last-name .th-sort');
   andThen(function() {
     customersSorted = customers.sortBy('lastName');
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(5)').text(), customersSorted[0].lastName, 'Sorting by last name');
-  });
-
-  click('th.admin-customers-col-birth .th-sort');
-  andThen(function() {
-    customersSorted = customers.sortBy('birth');
-    let expected = moment(customersSorted[0].nextBirthday).fromNow();
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(6)').text(), expected, 'Sorting by birth');
+    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(2)').text(), customersSorted[0].lastName, 'Sorting by last name');
   });
 
   click('th.admin-customers-col-phone .th-sort');
   andThen(function() {
     customersSorted = customers.sortBy('phone');
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(7)').text(), customersSorted[0].phone, 'Sorting by phone');
+    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(3)').text(), customersSorted[0].phone, 'Sorting by phone');
   });
 
   click('th.admin-customers-col-mail .th-sort');
   andThen(function() {
     customersSorted = customers.sortBy('mail');
-    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(8)').text(), customersSorted[0].mail, 'Sorting by mail');
+    assert.equal(find('.admin-customers tbody tr:nth-of-type(1) td:nth-of-type(4)').text(), customersSorted[0].mail, 'Sorting by mail');
   });
 
   click('th.admin-customers-col-note .th-sort');


### PR DESCRIPTION
- Shuffle columns so that they are in more logical order.
- Make table horizontally scrollable for mobile.
- Fix #119 