### PR TITLE
(maint) Entity creation hotfix

### DIFF
--- a/frontend/app/entity/model.js
+++ b/frontend/app/entity/model.js
@@ -3,9 +3,9 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   name: DS.attr('string'),
   invoiceHeader: DS.attr('string'),
-  vatid: DS.attr('string'),
-  premisesid: DS.attr('string'),
-  registerid: DS.attr('string'),
+  vatid: DS.attr('string', { defaultValue: "" }),
+  premisesid: DS.attr('string', { defaultValue: "" }),
+  registerid: DS.attr('string', { defaultValue: "" }),
   sendEet: DS.attr('boolean'),
   headquarters: DS.attr('string'),
   identificationNumber: DS.attr('string'),


### PR DESCRIPTION
- Without default values in model, it is not possible to create entity in some cases, because of db constraints.